### PR TITLE
Update layout templating for easier email adding later

### DIFF
--- a/src/css/scss/_type.scss
+++ b/src/css/scss/_type.scss
@@ -16,7 +16,6 @@ h4 {
 
 h1 {
   font-size: 38px;
-  text-transform: capitalize;
   font-weight: 300;
 }
 h2 {

--- a/src/emails/accountCreatedEmail.hbs
+++ b/src/emails/accountCreatedEmail.hbs
@@ -1,10 +1,10 @@
 ---
+description: Sent when a user creates a new account from within the app
 layout: default.hbs
-subject: Simple GitKraken Email
-<!-- preheader: This is preheader text. Some clients will show this text as a preview. -->
-<!-- preheader-notice: Some custom header content. <a href="#">And a link</a>? -->
+subject: GitKraken — Account Created
 header: Thank you for creating a GitKraken account
-<!-- footer-notice: You can add as many custom footer elements as you like, just like in the header. <a href="#" target="_blank">Example link</a>. -->
 ---
 
-<p>If you did not create a GitKraken account, please <a href='%LINK_URL%'>contact us</a>.</p>
+<p class='align-center'>
+  If you did not create a GitKraken account, please <a href='%LINK_URL%'>contact us</a>.
+</p>

--- a/src/emails/accountCreatedEmail.hbs
+++ b/src/emails/accountCreatedEmail.hbs
@@ -1,7 +1,7 @@
 ---
 description: Sent when a user creates a new account from within the app
 layout: default.hbs
-subject: GitKraken — Account Created
+subject: GitKraken — Account created
 header: Thank you for creating a GitKraken account
 ---
 

--- a/src/emails/accountCreatedEmail.hbs
+++ b/src/emails/accountCreatedEmail.hbs
@@ -1,0 +1,10 @@
+---
+layout: default.hbs
+subject: Simple GitKraken Email
+<!-- preheader: This is preheader text. Some clients will show this text as a preview. -->
+<!-- preheader-notice: Some custom header content. <a href="#">And a link</a>? -->
+header: Thank you for creating a GitKraken account
+<!-- footer-notice: You can add as many custom footer elements as you like, just like in the header. <a href="#" target="_blank">Example link</a>. -->
+---
+
+<p>If you did not create a GitKraken account, please <a href='%LINK_URL%'>contact us</a>.</p>

--- a/src/emails/activationEmail.hbs
+++ b/src/emails/activationEmail.hbs
@@ -1,0 +1,10 @@
+---
+layout: default.hbs
+subject: Simple GitKraken Email
+<!-- preheader: This is preheader text. Some clients will show this text as a preview. -->
+<!-- preheader-notice: Some custom header content. <a href="#">And a link</a>? -->
+header: Activate your GitKraken installation
+<!-- footer-notice: You can add as many custom footer elements as you like, just like in the header. <a href="#" target="_blank">Example link</a>. -->
+---
+
+<p>If you did not create a GitKraken account, please <a href='%LINK_URL%'>contact us</a>.</p>

--- a/src/emails/activationEmail.hbs
+++ b/src/emails/activationEmail.hbs
@@ -1,10 +1,10 @@
 ---
+description: A legacy email sent out for users on pre v1.5.0 GitKraken on registering the app
 layout: default.hbs
-subject: Simple GitKraken Email
-<!-- preheader: This is preheader text. Some clients will show this text as a preview. -->
-<!-- preheader-notice: Some custom header content. <a href="#">And a link</a>? -->
+subject: GitKraken — Verify your email address
 header: Activate your GitKraken installation
-<!-- footer-notice: You can add as many custom footer elements as you like, just like in the header. <a href="#" target="_blank">Example link</a>. -->
 ---
 
-<p>If you did not create a GitKraken account, please <a href='%LINK_URL%'>contact us</a>.</p>
+<p class='align-center'>
+  If you did not create a GitKraken account, please <a href='%LINK_URL%'>contact us</a>.
+</p>

--- a/src/emails/gitkraken.hbs
+++ b/src/emails/gitkraken.hbs
@@ -1,47 +1,24 @@
 ---
 layout: default.hbs
 subject: Simple GitKraken Email
+preheader: This is preheader text. Some clients will show this text as a preview.
+preheader-notice: Some custom header content. <a href="#">And a link</a>?
+header: Simple responsive HTML email template
+footer-notice: You can add as many custom footer elements as you like, just like in the header. <a href="#" target="_blank">Example link</a>.
 ---
-<span class="preheader">This is preheader text. Some clients will show this text as a preview.</span>
 
-{{> header-notice-open }}
-  <p>Some custom header content. <a href="#">And a link</a>?</p>
-{{> header-notice-close }}
+<p>
+  Ugh skateboard selfies sustainable, actually messenger bag brooklyn godard irony sriracha marfa craft beer. Waistcoat freegan tofu crucifix meditation, kitsch green juice seitan. Ramps cray brunch distillery, lumbersexual godard humblebrag tote bag forage cold-pressed chicharrones offal pitchfork. Drinking vinegar salvia lumbersexual, jean shorts letterpress 8-bit DIY ennui. Trust fund ennui small batch, celiac tacos synth DIY deep v. Direct trade four dollar toast cliche, thundercats hoodie celiac occupy. Dreamcatcher four loko twee VHS, scenester crucifix 90's health goth photo booth.
+</p>
 
-{{> axosoft-logo }}
+{{> button type='primary' align='center' url='https://www.gitkraken.com' title='Example CTA button' }}
 
-<table class="main">
+<p>
+  Slow-carb locavore taxidermy, literally church-key XOXO fanny pack affogato direct trade polaroid pop-up. Flannel narwhal austin, kinfolk pour-over vegan authentic schlitz locavore cronut 90's banh mi blog flexitarian. Godard chillwave hashtag, affogato migas four loko cornhole lo-fi helvetica master cleanse.
+</p>
 
-  {{> banner-row link='https://www.gitkraken.com' image='email-banner-1.jpg' }}
+{{> divider }}
 
-  <tr>
-    <td class="wrapper">
-      <table>
-        <tr>
-          <td>
-            <h1 class="align-center">Simple responsive HTML email template</h1>
-            <p>Ugh skateboard selfies sustainable, actually messenger bag brooklyn godard irony sriracha marfa craft beer. Waistcoat freegan tofu crucifix meditation, kitsch green juice seitan. Ramps cray brunch distillery, lumbersexual godard humblebrag tote bag forage cold-pressed chicharrones offal pitchfork. Drinking vinegar salvia lumbersexual, jean shorts letterpress 8-bit DIY ennui. Trust fund ennui small batch, celiac tacos synth DIY deep v. Direct trade four dollar toast cliche, thundercats hoodie celiac occupy. Dreamcatcher four loko twee VHS, scenester crucifix 90's health goth photo booth.</p>
-
-            {{> button type='primary' align='center' url='https://www.gitkraken.com' title='Example CTA button' }}
-
-            <p>Slow-carb locavore taxidermy, literally church-key XOXO fanny pack affogato direct trade polaroid pop-up. Flannel narwhal austin, kinfolk pour-over vegan authentic schlitz locavore cronut 90's banh mi blog flexitarian. Godard chillwave hashtag, affogato migas four loko cornhole lo-fi helvetica master cleanse.</p>
-
-            {{> divider }}
-
-            <p>Williamsburg distillery four dollar toast gentrify synth. Disrupt pop-up cronut you probably haven't heard of them. Pitchfork beard whatever, pinterest photo booth schlitz chia fap PBR&amp;B taxidermy paleo freegan post-ironic tofu health goth. Migas readymade franzen fap normcore 3 wolf moon.</p>
-
-          </td>
-        </tr>
-      </table>
-    </td>
-  </tr>
-</table>
-<div class="footer">
-
-  {{> footer-address }}
-
-  {{> footer-notice-open }}
-    <p>You can add as many custom footer elements as you like, just like in the header. <a href="#" target="_blank">Example link</a>.</p>
-  {{> footer-notice-close }}
-  
-</div>
+<p>
+  Williamsburg distillery four dollar toast gentrify synth. Disrupt pop-up cronut you probably haven't heard of them. Pitchfork beard whatever, pinterest photo booth schlitz chia fap PBR&amp;B taxidermy paleo freegan post-ironic tofu health goth. Migas readymade franzen fap normcore 3 wolf moon.
+</p>

--- a/src/emails/organizationInviteEmail.hbs
+++ b/src/emails/organizationInviteEmail.hbs
@@ -1,7 +1,7 @@
 ---
 description: Sent to a user who already has a GitKraken account after being invited to join an organization
 layout: default.hbs
-subject: GitKraken — You've been invited to use %PLAN_NAME%!
+subject: You've been invited to use %PLAN_NAME%!
 header: You've been invited to use %PLAN_NAME% with %ORG_NAME%
 ---
 

--- a/src/emails/organizationInviteEmail.hbs
+++ b/src/emails/organizationInviteEmail.hbs
@@ -1,10 +1,10 @@
 ---
+description: Sent to a user who already has a GitKraken account after being invited to join an organization
 layout: default.hbs
-subject: Simple GitKraken Email
-<!-- preheader: This is preheader text. Some clients will show this text as a preview. -->
-<!-- preheader-notice: Some custom header content. <a href="#">And a link</a>? -->
+subject: GitKraken — You've been invited to use %PLAN_NAME%!
 header: You've been invited to use %PLAN_NAME% with %ORG_NAME%
-<!-- footer-notice: You can add as many custom footer elements as you like, just like in the header. <a href="#" target="_blank">Example link</a>. -->
 ---
 
-<p><a href='%LINK_URL%'>Click here</a> to learn more about your new %PLAN_NAME% account.</p>
+<p class='align-center'>
+  <a href='%MORE_INFO_URL%'>Click here</a> to learn more about your new %PLAN_NAME% account.
+</p>

--- a/src/emails/organizationInviteEmail.hbs
+++ b/src/emails/organizationInviteEmail.hbs
@@ -1,0 +1,10 @@
+---
+layout: default.hbs
+subject: Simple GitKraken Email
+<!-- preheader: This is preheader text. Some clients will show this text as a preview. -->
+<!-- preheader-notice: Some custom header content. <a href="#">And a link</a>? -->
+header: You've been invited to use %PLAN_NAME% with %ORG_NAME%
+<!-- footer-notice: You can add as many custom footer elements as you like, just like in the header. <a href="#" target="_blank">Example link</a>. -->
+---
+
+<p><a href='%LINK_URL%'>Click here</a> to learn more about your new %PLAN_NAME% account.</p>

--- a/src/emails/organizationInviteNewUserEmail.hbs
+++ b/src/emails/organizationInviteNewUserEmail.hbs
@@ -1,14 +1,16 @@
 ---
+description: Sent to a user with no GitKraken account after being invited to use GitKraken
 layout: default.hbs
-subject: Simple GitKraken Email
-<!-- preheader: This is preheader text. Some clients will show this text as a preview. -->
-<!-- preheader-notice: Some custom header content. <a href="#">And a link</a>? -->
+subject: GitKraken — You've been invited to use %PLAN_NAME%!
 header: You've been invited to use %PLAN_NAME% with %ORG_NAME%
-<!-- footer-notice: You can add as many custom footer elements as you like, just like in the header. <a href="#" target="_blank">Example link</a>. -->
 ---
 
-<p><a href='%LINK_URL%'>Register</a> your account to begin using %PLAN_NAME%.</p>
+<p class='align-center'>
+  <a href='%LINK_URL%'>Register</a> your account to begin using %PLAN_NAME%.
+</p>
 
 {{> button type='primary' align='center' url='%LINK_URL%' title='Register' }}
 
-<p>After registering, <a href='%LINK_URL%'>click here</a> to learn more about your new %PLAN_NAME% account.</p>
+<p class='align-center'>
+  After registering, <a href='%MORE_INFO_URL%'>click here</a> to learn more about your new %PLAN_NAME% account.
+</p>

--- a/src/emails/organizationInviteNewUserEmail.hbs
+++ b/src/emails/organizationInviteNewUserEmail.hbs
@@ -1,7 +1,7 @@
 ---
 description: Sent to a user with no GitKraken account after being invited to use GitKraken
 layout: default.hbs
-subject: GitKraken — You've been invited to use %PLAN_NAME%!
+subject: You've been invited to use %PLAN_NAME%!
 header: You've been invited to use %PLAN_NAME% with %ORG_NAME%
 ---
 

--- a/src/emails/organizationInviteNewUserEmail.hbs
+++ b/src/emails/organizationInviteNewUserEmail.hbs
@@ -1,0 +1,14 @@
+---
+layout: default.hbs
+subject: Simple GitKraken Email
+<!-- preheader: This is preheader text. Some clients will show this text as a preview. -->
+<!-- preheader-notice: Some custom header content. <a href="#">And a link</a>? -->
+header: You've been invited to use %PLAN_NAME% with %ORG_NAME%
+<!-- footer-notice: You can add as many custom footer elements as you like, just like in the header. <a href="#" target="_blank">Example link</a>. -->
+---
+
+<p><a href='%LINK_URL%'>Register</a> your account to begin using %PLAN_NAME%.</p>
+
+{{> button type='primary' align='center' url='%LINK_URL%' title='Register' }}
+
+<p>After registering, <a href='%LINK_URL%'>click here</a> to learn more about your new %PLAN_NAME% account.</p>

--- a/src/emails/passwordEmail.hbs
+++ b/src/emails/passwordEmail.hbs
@@ -1,10 +1,10 @@
 ---
+description: Sent when a user creates an account from within the store
 layout: default.hbs
-subject: Simple GitKraken Email
-<!-- preheader: This is preheader text. Some clients will show this text as a preview. -->
-<!-- preheader-notice: Some custom header content. <a href="#">And a link</a>? -->
-header: Activate your GitKraken installation
-<!-- footer-notice: You can add as many custom footer elements as you like, just like in the header. <a href="#" target="_blank">Example link</a>. -->
+subject: GitKraken — Confirm your account
+header: Activate your GitKraken Account
 ---
 
-<p><a href='%LINK_URL%'>Click here</a> to confirm your account.</p>
+<p class='align-center'>
+  <a href='%LINK_URL%'>Click here</a> to confirm your account.
+</p>

--- a/src/emails/passwordEmail.hbs
+++ b/src/emails/passwordEmail.hbs
@@ -2,7 +2,7 @@
 description: Sent when a user creates an account from within the store
 layout: default.hbs
 subject: GitKraken — Confirm your account
-header: Activate your GitKraken Account
+header: Activate your GitKraken account
 ---
 
 <p class='align-center'>

--- a/src/emails/passwordEmail.hbs
+++ b/src/emails/passwordEmail.hbs
@@ -1,0 +1,10 @@
+---
+layout: default.hbs
+subject: Simple GitKraken Email
+<!-- preheader: This is preheader text. Some clients will show this text as a preview. -->
+<!-- preheader-notice: Some custom header content. <a href="#">And a link</a>? -->
+header: Activate your GitKraken installation
+<!-- footer-notice: You can add as many custom footer elements as you like, just like in the header. <a href="#" target="_blank">Example link</a>. -->
+---
+
+<p><a href='%LINK_URL%'>Click here</a> to confirm your account.</p>

--- a/src/emails/passwordResetEmail.hbs
+++ b/src/emails/passwordResetEmail.hbs
@@ -1,14 +1,16 @@
 ---
 layout: default.hbs
-subject: Simple GitKraken Email
-<!-- preheader: This is preheader text. Some clients will show this text as a preview. -->
-<!-- preheader-notice: Some custom header content. <a href="#">And a link</a>? -->
+subject: GitKraken — Reset your password
 header: Reset your GitKraken account password
 footer-notice: Didn't want to reset your password? <a href="%CANCEL_URL%" target="_blank">Click here</a>.
 ---
 
-<p>You recently requesed a password reset for your GitKraken account. Click the button bellow to reset your password.</p>
+<p>
+  You recently requesed a password reset for your GitKraken account. Click the button below to reset your password.
+</p>
 
 {{> button type='primary' align='center' url='%LINK_URL%' title='Reset Password' }}
 
-<p>This password reset will expire in %EXPIRES_IN_HOURS% hours.</p>
+<p>
+  This password reset will expire in %EXPIRES_IN_HOURS% hours.
+</p>

--- a/src/emails/passwordResetEmail.hbs
+++ b/src/emails/passwordResetEmail.hbs
@@ -6,7 +6,7 @@ footer-notice: Didn't want to reset your password? <a href="%CANCEL_URL%" target
 ---
 
 <p>
-  You recently requesed a password reset for your GitKraken account. Click the button below to reset your password.
+  You recently requested to reset your GitKraken account password. Click the button below to reset your password.
 </p>
 
 {{> button type='primary' align='center' url='%LINK_URL%' title='Reset Password' }}

--- a/src/emails/passwordResetEmail.hbs
+++ b/src/emails/passwordResetEmail.hbs
@@ -1,0 +1,14 @@
+---
+layout: default.hbs
+subject: Simple GitKraken Email
+<!-- preheader: This is preheader text. Some clients will show this text as a preview. -->
+<!-- preheader-notice: Some custom header content. <a href="#">And a link</a>? -->
+header: Reset your GitKraken account password
+footer-notice: Didn't want to reset your password? <a href="%CANCEL_URL%" target="_blank">Click here</a>.
+---
+
+<p>You recently requesed a password reset for your GitKraken account. Click the button bellow to reset your password.</p>
+
+{{> button type='primary' align='center' url='%LINK_URL%' title='Reset Password' }}
+
+<p>This password reset will expire in %EXPIRES_IN_HOURS% hours.</p>

--- a/src/layouts/default.hbs
+++ b/src/layouts/default.hbs
@@ -10,13 +10,70 @@
 <body>
 
 <table class="body">
-	<tr>
-		<td></td>
-		<td class="container">
-			<div class="content">{{ body }}</div>
-		</td>
-		<td></td>
-	</tr>
+  <tr>
+    <td></td>
+    <td class="container">
+      <div class="content">
+
+        {{#if preheader }}
+        <span class="preheader">
+          {{ preheader }}
+        </span>
+        {{/if}}
+
+        {{#if preheader-notice}}
+        {{> header-notice-open }}
+          <p>
+            {{{ preheader-notice }}}
+          </p>
+        {{> header-notice-close }}
+        {{/if}}
+
+        {{> axosoft-logo }}
+
+        <table class="main">
+
+          {{>
+            banner-row
+            link='https://www.gitkraken.com'
+            image='email-banner-1.jpg'
+          }}
+
+          <tr>
+            <td class="wrapper">
+              <table>
+                <tr>
+                  <td>
+                    <h1 class="align-center">
+                      {{{ header }}}
+                    </h1>
+
+                    {{ body }}
+
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+        <div class="footer">
+
+          {{> footer-address }}
+
+          {{#if footer-notice }}
+          {{> footer-notice-open }}
+            <p>
+              {{{ footer-notice }}}
+            </p>
+          {{> footer-notice-close }}
+          {{/if}}
+
+        </div>
+
+      </div>
+    </td>
+    <td></td>
+  </tr>
 </table>
 
 </body>

--- a/src/partials/components/divider.hbs
+++ b/src/partials/components/divider.hbs
@@ -1,11 +1,11 @@
 <table class="divider-wrapper">
-	<tr>
-		<td class="divider-spacer">
-			<table class="divider divider-{{ type }} {{ class }}" cellpadding="0" cellspacing="0">
-				<tr>
-					<td></td>
-				</tr>
-			</table>
-		</td>
-	</tr>
+  <tr>
+    <td class="divider-spacer">
+      <table class="divider divider-{{ type }} {{ class }}" cellpadding="0" cellspacing="0">
+        <tr>
+          <td></td>
+        </tr>
+      </table>
+    </td>
+  </tr>
 </table>

--- a/src/partials/components/notice.hbs
+++ b/src/partials/components/notice.hbs
@@ -1,18 +1,18 @@
 {{!
-	Notification Block
-	Params:
-		type:	(string) accepts 'info', 'success', 'warning', 'danger'
-		class: (string) opional classes you may want to apply such as 'align-center'
-		text: (string) unescaped, the text you wish to display in the notice
+  Notification Block
+  Params:
+    type:  (string) accepts 'info', 'success', 'warning', 'danger'
+    class: (string) opional classes you may want to apply such as 'align-center'
+    text: (string) unescaped, the text you wish to display in the notice
 }}
 <table class="notice-wrapper" cellpadding="0" cellspacing="0">
-	<tr>
-		<td class="notice-spacer">
-			<table class="notice notice-{{ type }} {{ class }}" cellpadding="0" cellspacing="0">
-				<tr>
-					<td>{{{ text }}}</td>
-				</tr>
-			</table>
-		</td>
-	</tr>
+  <tr>
+    <td class="notice-spacer">
+      <table class="notice notice-{{ type }} {{ class }}" cellpadding="0" cellspacing="0">
+        <tr>
+          <td>{{{ text }}}</td>
+        </tr>
+      </table>
+    </td>
+  </tr>
 </table>


### PR DESCRIPTION
@johndavidsparrow This basically moves the meat of the template to the `default.hbs` layout. Each future template should be able to use the parameters specified in default.hbs so things are somewhat simplified for adding a template in the future. The following are the parameters that can be passed into `default.hbs`:
```
preheader
preheader-notice
header
footer-notice
```
When any of these params are omitted, the corresponding element will be hidden for that template.